### PR TITLE
Fix SFTP config for Ubuntu

### DIFF
--- a/salt/roots/salt/ssh/sshd_config
+++ b/salt/roots/salt/ssh/sshd_config
@@ -115,7 +115,7 @@ PasswordAuthentication no
 #Banner none
 
 # override default of no subsystems
-Subsystem	sftp	/usr/libexec/sftp-server
+Subsystem	sftp	/usr/lib/openssh/sftp-server
 
 # Disable HPN tuning improvements.
 #HPNDisabled no


### PR DESCRIPTION
Broken config causes problems when testing "remote interpreter" setups in 
certain editors (e.g. pyCharm).
