### PR TITLE
Update Salt's virtualenv settings

### DIFF
--- a/salt/roots/salt/example-project/venv.sls
+++ b/salt/roots/salt/example-project/venv.sls
@@ -4,10 +4,11 @@ include:
 # Create the Python Virtual environment
 {{ pillar['django']['virtualenv'] }}:
   virtualenv.managed:
-    - no_site_packages: True
+    - system_site_packages: False
     - distribute: True
     - runas: {{ pillar['django']['user'] }}
     - requirements: {{ pillar['django']['path'] }}/requirements.txt  
+    - no_chown: True
     - require:
       - pkg: python-virtualenv
       - pkg: python-dev


### PR DESCRIPTION
1) no_site_packages option has been deprecated for system_site_packages
2) if the requirements file has references to other requirement files on the file system, Salt will break unless no_chown option is given which prevents Salt from copying the requirements file to /tmp/ before running.
