### PR TITLE
Make uWSGI directory apps-available.

### DIFF
--- a/salt/roots/salt/uwsgi/init.sls
+++ b/salt/roots/salt/uwsgi/init.sls
@@ -12,6 +12,15 @@ uwsgi:
       - pkg: python-dev
       - pkg: python-pip
 
+/etc/uwsgi/apps-available:
+  file.directory:
+    - user: www-data
+    - group: www-data
+    - makedirs: true
+    - require:
+      - pip: uwsgi
+      - pkg: nginx
+
 /etc/uwsgi/apps-enabled:
   file.directory:
     - user: www-data


### PR DESCRIPTION
Not sure if something changed in PyPI or Ubuntu packages, but the
/etc/uwsgi/apps-available directory stopped being auto-created
which causes other uWSGI salt tasks to fail.
