### PR TITLE
As of vagrant 1.3, salt is now officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Django salted requires the following software to be installed on your machine:
 
 - [Virtualbox]
 - [Vagrant]
-- [Salty Vagrant]
 
 You also need [Fabric] and [Fabtools] if you want to run the Fabric
 commands. You can find these requirements in the [requirements.txt] file in


### PR DESCRIPTION
Removed the requirement for [Salty Vagrant] as `salt` is officially supported in Vagrant version 1.3 and above.
